### PR TITLE
Add Generic Device Plugin for tun and change restart policy

### DIFF
--- a/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: generic-device-plugin
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.4.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+
+  values:
+    defaultPodOptions:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
+          effect: "NoExecute"
+        - operator: "Exists"
+          effect: "NoSchedule"
+    controllers:
+      generic-device-plugin:
+        containers:
+          generic-device-plugin:
+            image:
+              repository: ghcr.io/squat/generic-device-plugin
+              tag: 36bfc606bba2064de6ede0ff2764cbb52edff70d@sha256:ba6f0b4cf6c858d6ad29ba4d32e4da11638abbc7d96436bf04f582a97b2b8821
+            args:
+              - --domain
+              - kernel.org
+              - --device
+              - |
+                name: tun
+                groups:
+                  - count: 1000
+                    paths:
+                      - path: /dev/net/tun
+            ports:
+              - containerPort: 8080
+                name: http
+            resources:
+              requests:
+                cpu: 20m
+                memory: 48Mi
+              limits:
+                cpu: 200m
+                memory: 48Mi
+            securityContext:
+              privileged: true
+              readOnlyRootFilesystem: true
+
+    persistence:
+      dev:
+        type: hostPath
+        hostPath: /dev
+        globalMounts:
+          - path: /dev
+      device-plugin:
+        type: hostPath
+        hostPath: /var/lib/kubelet/device-plugins
+        globalMounts:
+          - path: /var/lib/kubelet/device-plugins

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app generic-device-plugin
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/kube-system/generic-device-plugin/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml
+  - ./generic-device-plugin/ks.yaml
   - ./intel-device-plugin/ks.yaml
   - ./metrics-server/ks.yaml
   - ./node-feature-discovery/ks.yaml

--- a/kubernetes/apps/media/qbittorrent/torrent-standard/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/torrent-standard/helmrelease.yaml
@@ -126,6 +126,9 @@ spec:
                 add:
                   - NET_ADMIN
               allowPrivilegeEscalation: false
+            resources:
+              limits:
+                kernel.org/tun: 1
 
           port-forward:
             image:
@@ -136,6 +139,7 @@ spec:
               CRON_ENABLED: true
               CRON_SCHEDULE: "*/5 * * * *"
               LOG_TIMESTAMP: false
+            restartPolicy: Always
             securityContext:
               runAsUser: 568
               runAsGroup: 568


### PR DESCRIPTION
- Generic Device Plugin is used to expose your `/dev/net/tun` device
- Restart Policy for init containers should be set to "Always" if they are expected to be sidecar containers, port-forward is expected to run from the time the container starts, until it stops, meaning it should be a sidecar container. Regular init containers are expected to simply complete a job, then return an exit code on completion. 

https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/