### PR TITLE
CoreDNS: Optimize for single node setup

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helm-values.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helm-values.yaml
@@ -1,6 +1,9 @@
 ---
 fullnameOverride: coredns
 k8sAppLabelOverride: kube-dns
+replicaCount: 2
+rollingUpdate:
+  maxSurge: 1
 serviceAccount:
   create: true
 service:
@@ -48,10 +51,3 @@ tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
     effect: NoSchedule
-topologySpreadConstraints:
-  - maxSkew: 1
-    topologyKey: kubernetes.io/hostname
-    whenUnsatisfiable: DoNotSchedule
-    labelSelector:
-      matchLabels:
-        app.kubernetes.io/instance: coredns


### PR DESCRIPTION
I am assuming you still only have a single node like I do. 
I fixed coreDNS causing outages during updates by making the following changes. 

1. `replicaCount: 2` Ensures two pods are available on the server.
2. `rollingUpdate.maxSurge: 1` When updating, it temporarily allows an additional pod on the server, for a max of 3.
3. Removed `topologySpreadConstraints` since it limits the number of pods allows for each node, since we want two replicas, it has to go. Generally not needed for single node setups anyway. 

You could also just remove the `topologySpreadConstraints`, keep replicas to `1`, and keep `rollingUpdate.maxSurge: 1`. That would also fix the issue, but id rather just have two pods up. 